### PR TITLE
Improve error handling

### DIFF
--- a/hipchat.go
+++ b/hipchat.go
@@ -178,8 +178,8 @@ func (c *Client) RoomList() ([]Room, error) {
 	return roomsResp.Rooms, nil
 }
 
-// getError is a small helper function for getting and returning the error from
-// hipchat.
+// getError unmarshals a HipChat error response from the request body and
+// returns its error field.
 func getError(body []byte) error {
 	var errResp ErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {


### PR DESCRIPTION
- Return optionally structured errors with more information.

```
if hcErr, ok := err.(hipchat.Error); ok {
    log.Printf("[%d] %q", hcErr.Code, hcErr.Message)
}
```
- Actually return the error if a message wasn't posted.

This removes the human friendly error message being reported by https://github.com/andybons/hipchat/issues/8 and returns a standard Hipchat.Error instead.
