### PR TITLE
Add AuthTest support for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ Contributors
 + Tarrant Rollins ([@tarrant](https://github.com/tarrant))
 + Edward Muller ([@freeformz](https://github.com/freeformz))
 + Matt Blair ([@mblair](https://github.com/mblair))
++ Gordon Goetz ([@gtosh4](https://github.com/gtosh4))


### PR DESCRIPTION
This will allow `rooms/message` API calls to use the 'auth_test' flag described here:
https://www.hipchat.com/docs/api/auth

The response type is different than a normal request. Catch the 'success' vs 'error' response and return the error if present (nil if successfully authenticated).